### PR TITLE
Add `offset` configuration support to Fiddler receiver

### DIFF
--- a/receiver/fiddlerreceiver/config.go
+++ b/receiver/fiddlerreceiver/config.go
@@ -14,6 +14,8 @@ const (
 	defaultTimeout   = 5 * time.Minute
 	defaultInterval  = 5 * time.Minute
 	minimumInterval  = 5 * time.Minute
+	defaultOffset    = 1 * time.Hour
+	maximumOffset    = 48 * time.Hour
 )
 
 var defaultEnabledMetricTypes = []string{"drift", "traffic", "performance", "statistic", "service_metrics"}
@@ -34,6 +36,9 @@ type Config struct {
 
 	// EnabledMetricTypes is the list of metric types to collect
 	EnabledMetricTypes []string `mapstructure:"enabled_metric_types"`
+
+	// Offset (in hours) for calculating start time for metrics collection
+	Offset time.Duration `mapstructure:"offset"`
 }
 
 func (cfg *Config) Validate() error {
@@ -47,7 +52,6 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Interval == 0 {
 		cfg.Interval = defaultInterval
-		return nil
 	}
 
 	if cfg.Interval < minimumInterval {
@@ -56,6 +60,14 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Timeout <= 0 {
 		return fmt.Errorf("timeout must be greater than 0")
+	}
+
+	if cfg.Offset == 0 {
+		cfg.Offset = defaultOffset
+	}
+
+	if cfg.Offset > maximumOffset {
+		return fmt.Errorf("offset must be no more than %d hours", int(maximumOffset/time.Hour))
 	}
 
 	return nil

--- a/receiver/fiddlerreceiver/internal/client/client.go
+++ b/receiver/fiddlerreceiver/internal/client/client.go
@@ -117,6 +117,7 @@ func (c *HTTPClient) call(ctx context.Context, method, endpoint string, jsonRequ
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Integration", "fiddler-otel-receiver")
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/receiver/fiddlerreceiver/receiver.go
+++ b/receiver/fiddlerreceiver/receiver.go
@@ -60,6 +60,7 @@ func (fr *fiddlerReceiver) Start(ctx context.Context, host component.Host) error
 	fr.logger.Info("Starting Fiddler metrics receiver",
 		zap.String("endpoint", fr.config.Endpoint),
 		zap.Duration("interval", fr.config.Interval),
+		zap.Duration("offset", fr.config.Offset),
 		zap.Strings("enabled_metric_types", fr.config.EnabledMetricTypes),
 	)
 
@@ -158,7 +159,7 @@ func (fr *fiddlerReceiver) collect(ctx context.Context) error {
 
 		// Calculate time range for query
 		endTime := time.Now()
-		startTime := endTime.Add(-defaultBinSize)
+		startTime := endTime.Add(-fr.config.Offset)
 
 		// Prepare query request
 		request := client.QueryRequest{}


### PR DESCRIPTION
- When the Fiddler receiver is configured with an `offset`, the start time for collecting the metrics data is set to current time - offset
- Maximum offset that can be configured on the receiver is 48 hours
- The offset is to be configured in hours (e.g. `2h`, `24h`, etc)

### How was this tested?
This was tested against `otelreceivertest.dev` deployment with the custom OTel collector pipeline running through https://github.com/fiddler-labs/otel-collector-with-fiddler/blob/main/docker-compose.yml.

<img width="1496" height="934" alt="image" src="https://github.com/user-attachments/assets/dd85c790-6b3c-483f-945b-03ce7518a29a" />
